### PR TITLE
Swap std::map<>::emplace with std::map<>::insert in FontRederer::add_text()

### DIFF
--- a/src/Graphics/2D/FontRenderer.cpp
+++ b/src/Graphics/2D/FontRenderer.cpp
@@ -46,7 +46,7 @@ FontRenderer::~FontRenderer() {}
 
 auto FontRenderer::add_text(std::string text, glm::vec2 position,
                             Rendering::Color color) -> void {
-    stringMap.insert(text, ColorPos{position, color});
+    stringMap.insert(std::make_pair(text, ColorPos{position, color}));
     rebuild();
 }
 

--- a/src/Graphics/2D/FontRenderer.cpp
+++ b/src/Graphics/2D/FontRenderer.cpp
@@ -46,7 +46,7 @@ FontRenderer::~FontRenderer() {}
 
 auto FontRenderer::add_text(std::string text, glm::vec2 position,
                             Rendering::Color color) -> void {
-    stringMap.emplace(text, ColorPos{position, color});
+    stringMap.insert(text, ColorPos{position, color});
     rebuild();
 }
 


### PR DESCRIPTION
Allows font elements with duplicate strings to be created and drawn.