### PR TITLE
Sprite uvs same order as AnimatedSprite

### DIFF
--- a/src/Graphics/2D/Sprite.cpp
+++ b/src/Graphics/2D/Sprite.cpp
@@ -95,25 +95,25 @@ auto Sprite::update_mesh() -> void {
         mesh = create_scopeptr<Rendering::FixedMesh<Rendering::Vertex, 4, 6>>();
 
     mesh->vertices[0] = Rendering::Vertex{
-        selection.position.x, selection.position.y, color,
+        selection.position.x, selection.position.y + selection.extent.y, color,
         bounds.position.x,    bounds.position.y,    (float)layer};
     mesh->vertices[1] =
         Rendering::Vertex{selection.position.x + selection.extent.x,
-                          selection.position.y,
+                          selection.position.y + selection.extent.y,
                           color,
                           bounds.position.x + bounds.extent.x,
                           bounds.position.y,
                           (float)layer};
     mesh->vertices[2] =
         Rendering::Vertex{selection.position.x + selection.extent.x,
-                          selection.position.y + selection.extent.y,
+                          selection.position.y ,
                           color,
                           bounds.position.x + bounds.extent.x,
                           bounds.position.y + bounds.extent.y,
                           (float)layer};
     mesh->vertices[3] =
-        Rendering::Vertex{selection.position.x,
-                          selection.position.y + selection.extent.y,
+        Rendering::Vertex{selection.position.x ,
+                          selection.position.y ,
                           color,
                           bounds.position.x,
                           bounds.position.y + bounds.extent.y,


### PR DESCRIPTION
Animated Sprite and Normal Sprite use diferent uvs order. This cause  Sprite to be inverted and AnimatedSprite look good. 

Evidence of the problem: 
 
![eV8V50h](https://user-images.githubusercontent.com/10296859/220904746-f0a872a3-4e25-466e-9883-57998ffd5a10.png)
